### PR TITLE
Changing the mapper between Admin and AdminDTO

### DIFF
--- a/HMS/HMS/Mappings/MappingProfile.cs
+++ b/HMS/HMS/Mappings/MappingProfile.cs
@@ -18,14 +18,12 @@ namespace HMS.Mappings
 
             //Create Auto Mapper for Admin and AdminDTO and vise versa
 
-            CreateMap<AdminDTO, Admin>()
-                .ForMember(dest => dest.PasswordHash,
-                opt => opt.Ignore());
-
-
             CreateMap<Admin, AdminDTO>()
+                .ForMember(dest => dest.Password, opt => opt.MapFrom(src => src.PasswordHash))
                 .ForMember(dest => dest.AlreadyExists,
                 opt => opt.Ignore());
+
+            CreateMap<AdminDTO, Admin>();
 
             //Reservation: CheckOutDate must be later than CheckInDate.
 


### PR DESCRIPTION
I have changed the mapper between Admin and AdminDTO to add explicit mapping between the Password and PasswordHash properties in both classes because they dont follow the name convention, therefore they need to be mapped manually.